### PR TITLE
SAGE-1262: restore the /etc/waggle/firewall folder to the debian package

### DIFF
--- a/ROOTFS/etc/waggle/firewall/.placeholder
+++ b/ROOTFS/etc/waggle/firewall/.placeholder
@@ -1,0 +1,1 @@
+# place holder file to create the ./rules path


### PR DESCRIPTION
This eliminates an upgrade from removing the /etc/waggle/firewall directory
in systems, deleting user's custom firewall rules, and causing the
firewall service to fail.